### PR TITLE
Fix: Prevent premature Live TV stream closure for concurrent viewers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -196,6 +196,7 @@
  - [benedikt257](https://github.com/benedikt257)
  - [revam](https://github.com/revam)
  - [allesmi](https://github.com/allesmi)
+ - [fahmula](https://github.com/fahmula)
 
 # Emby Contributors
 


### PR DESCRIPTION
When multiple clients are watching the same Live TV channel, if one client stops their stream (e.g., closes the player, their HLS session times out, or WebSocket disconnects), the underlying M3U stream was being incorrectly closed for all remaining active viewers.

This occurred because SessionManager.CloseLiveStreamIfNeededAsync would flag the stream for closure if any associated session identifier was removed, without correctly verifying if other active client sessions (and their associated identifiers) for that same liveStreamId still existed.

This change modifies SessionManager.CloseLiveStreamIfNeededAsync to only flag the underlying live stream for closure if the activeSessionMappings collection (tracking active session identifiers for that liveStreamId) becomes completely empty after removing the current session's identifiers.

This ensures that the shared Live TV stream remains active as long as at least one client session is still actively associated with it, resolving the premature closure issue for concurrent viewers.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
